### PR TITLE
Change `pair` use to `tuple`

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -160,9 +160,9 @@ The {{LargestContentfulPaint/element}} attribute's getter must return the value 
 Note: The above algorithm defines that an element that is no longer <a>descendant</a> of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
-It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with <a>pairs</a> with an {{Element}} as the first item and a {{Request}} as the second item. This is used for performance, to enable the algorithm to only consider each content once.
+It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with ({{Element}}, {{Request}}) <a>tuples</a>. This is used for performance, to enable the algorithm to only consider each content once.
 
-Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>pairs</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
+Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>tuples</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
 
 Processing model {#sec-processing-model}
 ========================================
@@ -184,7 +184,7 @@ In order to <dfn export>potentially add a {{LargestContentfulPaint}} entry</dfn>
     ::  |document|, a <a>Document</a>
     : Output
     ::  None
-        1. Let |contentIdentifier| be the <a>pair</a> (|element|, |imageRequest|).
+        1. Let |contentIdentifier| be the <a>tuple</a> (|element|, |imageRequest|).
         1. If |document|'s [=content set=] <a for=set>contains</a> |contentIdentifier|, return.
         1. <a for=set>Append</a> |contentIdentifier| to |document|'s [=content set=]
         1. Let |window| be |document|’s [=relevant global object=].


### PR DESCRIPTION
The infra spec no longer defines `pair`, resulting in broken links. Moving to use `tuple` instead.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***

### :boom: Error: 500 Internal Server Error :boom: ###

[PR Preview](https://github.com/tobie/pr-preview#pr-preview) failed to build. _(Last tried on Mar 9, 2022, 3:31 PM UTC)_.

<details>
<summary>More</summary>


PR Preview relies on a number of web services to run. There seems to be an issue with the following one:

:rotating_light: [CSS Spec Preprocessor](https://api.csswg.org/bikeshed/) - CSS Spec Preprocessor is the web service used to build Bikeshed specs.

:link: [Related URL](https://api.csswg.org/bikeshed/?url=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Flargest-contentful-paint%2F73366cee407be84103abc4c346f0353075c3936b%2Findex.bs&md-warning=not%20ready)

```
Error running preprocessor, returned code: 1.
Traceback (most recent call last):
  File "/sites/api.csswg.org/bikeshed/bikeshed.py", line 3, in 
    from bikeshed import cli
  File "/sites/api.csswg.org/bikeshed/bikeshed/__init__.py", line 65, in 
    from . import config  # noqa: E402
  File "/sites/api.csswg.org/bikeshed/bikeshed/config/__init__.py", line 2, in 
    from .dfnTypes import (
  File "/sites/api.csswg.org/bikeshed/bikeshed/config/dfnTypes.py", line 4, in 
    from .. import t
  File "/sites/api.csswg.org/bikeshed/bikeshed/t.py", line 6, in 
    from typing import (
ImportError: cannot import name 'Literal' from 'typing' (/usr/local/lib/python3.7/typing.py)
```

_If you don't have enough information above to solve the error by yourself (or to understand to which web service the error is related to, if any), please [file an issue](https://github.com/tobie/pr-preview/issues/new?title=Error%20not%20surfaced%20properly&body=See%20w3c/largest-contentful-paint%2390.)._
</details>
