### PR TITLE
Add final slash to ED URL

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -6,8 +6,8 @@ Group: webperf
 Level: none
 Editor: Yoav Weiss, Google https://google.com, yoavweiss@chromium.org, w3cid 58673
 Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org, w3cid 103755
-TR: https://www.w3.org/TR/largest-contentful-paint/
-URL: https://w3c.github.io/largest-contentful-paint
+TR: https://www.w3.org/TR/largest-contentful-paint
+URL: https://w3c.github.io/largest-contentful-paint/
 Repository: https://github.com/w3c/largest-contentful-paint/
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/largest-contentful-paint
 Abstract: This document defines an API that enables monitoring the largest paint an element triggered on screen.

--- a/index.bs
+++ b/index.bs
@@ -8,7 +8,7 @@ Editor: Yoav Weiss, Google https://google.com, yoavweiss@chromium.org, w3cid 586
 Editor: Nicolás Peña Moreno, Google https://google.com, npm@chromium.org, w3cid 103755
 TR: https://www.w3.org/TR/largest-contentful-paint/
 URL: https://w3c.github.io/largest-contentful-paint
-Repository: https://github.com/w3c/largest-contentful-paint
+Repository: https://github.com/w3c/largest-contentful-paint/
 Test Suite: https://github.com/web-platform-tests/wpt/tree/master/largest-contentful-paint
 Abstract: This document defines an API that enables monitoring the largest paint an element triggered on screen.
 Default Highlight: js


### PR DESCRIPTION
Minor update to save a 301 Permanent redirect when someone wants to access the ED from the TR document.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/tidoust/largest-contentful-paint/pull/102.html" title="Last updated on Jun 9, 2022, 9:30 AM UTC (8b70e8a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/102/4a0930c...tidoust:8b70e8a.html" title="Last updated on Jun 9, 2022, 9:30 AM UTC (8b70e8a)">Diff</a>