### PR TITLE
isTrusted needs to be true for scroll events

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -244,7 +244,7 @@ Modifications to the DOM specification {#sec-modifications-DOM}
 
     Right after step 1, we add the following step:
 
-    * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{scroll}} and its {{Event/isTrusted}} is false, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
+    * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{scroll}} and its {{Event/isTrusted}} is true, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
 </div>
 
 Modifications to the HTML specification {#sec-modifications-HTML}


### PR DESCRIPTION
This fixes an issue reported on matrix by @sefeng211


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/pull/103.html" title="Last updated on Jul 4, 2022, 8:23 AM UTC (1a549db)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/103/4a0930c...1a549db.html" title="Last updated on Jul 4, 2022, 8:23 AM UTC (1a549db)">Diff</a>