### PR TITLE
Fix ambiguous references

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -158,7 +158,7 @@ The {{LargestContentfulPaint/url}} attribute must return the value of <a>this</a
 
 The {{LargestContentfulPaint/element}} attribute's getter must return the value returned by running the <a>get an element</a> algorithm with <a>element</a> and null as inputs.
 
-Note: The above algorithm defines that an element that is no longer <a>descendant</a> of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
+Note: The above algorithm defines that an element that is no longer a [=tree/descendant=] of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
 It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with ({{Element}}, {{Request}}) <a>tuples</a>. This is used for performance, to enable the algorithm to only consider each content once.
@@ -255,7 +255,7 @@ Modifications to the DOM specification {#sec-modifications-DOM}
 
     Right after step 1, we add the following step:
 
-    * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{scroll}} and its {{Event/isTrusted}} is true, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
+    * If |target|'s [=relevant global object=] is a {{Window}} object, <var ignore>event</var>'s {{Event/type}} is {{Document/scroll}} and its {{Event/isTrusted}} is true, set |target|'s [=relevant global object=]'s [=has dispatched scroll event=] to true.
 </div>
 
 Modifications to the HTML specification {#sec-modifications-HTML}


### PR DESCRIPTION
This fixes a couple of references which appear to have stopped the build from working.
It's unclear whether Document/scroll is entirely correct here; Event.type is properly a DOMString, but this links to the correct definition of that event (on Document, Visual Viewport and on Element)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/pull/117.html" title="Last updated on Sep 5, 2023, 8:21 PM UTC (c59c241)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/117/c2ed022...c59c241.html" title="Last updated on Sep 5, 2023, 8:21 PM UTC (c59c241)">Diff</a>