### PR TITLE
Exclude Transparent Texts From Being Eligible LCP Candidate

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -227,7 +227,7 @@ Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
         1. <a>Potentially add a LargestContentfulPaint entry</a> with |candidate|, |intersectionRect|, |now|, |record|'s [=pending image record/loadTime=] and |document|.
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
-        1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] >= 1, and the CSS property <a property>text-shadow</a> has value none, the 'stroke-color' value is 'transparent' and the 'stroke-image' value is none, continue.
+        1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] >= 1, and the CSS property <a property>text-shadow</a> has value none, the 'stroke-color' value is [=transparent=] and the 'stroke-image' value is none, continue.
         1. Let |candidate| be (|textNode|, null)
         1. Let |intersectionRect| be an empty rectangle.
         1. [=set/For each=] {{Text}} <a>node</a> |text| of |textNode|'s <a>set of owned text nodes</a>:

--- a/index.bs
+++ b/index.bs
@@ -189,7 +189,6 @@ The {{LargestContentfulPaint/element}} attribute's getter must perform the follo
 Note: The above algorithm defines that an element that is no longer a [=tree/descendant=] of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
-
 It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with ({{Element}}, {{Request}}) <a>tuples</a>. This is used for performance, to enable the algorithm to only consider each content once.
 
 Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>tuples</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.

--- a/index.bs
+++ b/index.bs
@@ -189,6 +189,7 @@ The {{LargestContentfulPaint/element}} attribute's getter must perform the follo
 Note: The above algorithm defines that an element that is no longer a [=tree/descendant=] of the {{Document}} will no longer be returned by {{LargestContentfulPaint/element}}'s attribute getter, including elements that are inside a shadow DOM.
 
 This specification also extends {{Document}} by adding to it a <dfn>largest contentful paint size</dfn> concept, initially set to 0.
+
 It also adds an associated <dfn>content set</dfn>, which is initially an empty <a spec=infra for=/>set</a>. The [=content set=] will be filled with ({{Element}}, {{Request}}) <a>tuples</a>. This is used for performance, to enable the algorithm to only consider each content once.
 
 Note: The user agent needs to maintain the [=content set=] so that removed content does not introduce memory leaks. In particular, it can tie the lifetime of the <a>tuples</a> to weak pointers to the {{Element|Elements}} so that it can be cleaned up sometime after the {{Element|Elements}} are removed. Since the <a spec=infra for=/>set</a> is not exposed to web developers, this does not expose garbage collection timing.
@@ -227,7 +228,7 @@ Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
         1. <a>Potentially add a LargestContentfulPaint entry</a> with |candidate|, |intersectionRect|, |now|, |record|'s [=pending image record/loadTime=] and |document|.
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
-        1. If |textNode| is transparent or otherwise invisible, continue.
+        1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] >= 1, and the CSS property <a property>text-shadow</a> has value none, the 'stroke-color' value is 'transparent' and the 'stroke-image' value is none, continue.
         1. Let |candidate| be (|textNode|, null)
         1. Let |intersectionRect| be an empty rectangle.
         1. [=set/For each=] {{Text}} <a>node</a> |text| of |textNode|'s <a>set of owned text nodes</a>:

--- a/index.bs
+++ b/index.bs
@@ -227,7 +227,8 @@ Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
         1. <a>Potentially add a LargestContentfulPaint entry</a> with |candidate|, |intersectionRect|, |now|, |record|'s [=pending image record/loadTime=] and |document|.
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
-        1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] >= 1, and the CSS property <a property>text-shadow</a> has value none, the 'stroke-color' value is [=transparent=] and the 'stroke-image' value is none, continue.
+        1. If |textNode| has [=alpha channel=] value <=0 or [=opacity=] value <=0:
+            1. If |textNode|'s <a property>text-shadow</a> value is none, |textNode|'s 'stroke-color' value is [=transparent=] and |textNode|'s 'stroke-image' value is none, continue.
         1. Let |candidate| be (|textNode|, null)
         1. Let |intersectionRect| be an empty rectangle.
         1. [=set/For each=] {{Text}} <a>node</a> |text| of |textNode|'s <a>set of owned text nodes</a>:

--- a/index.bs
+++ b/index.bs
@@ -227,6 +227,7 @@ Report Largest Contentful Paint {#sec-report-largest-contentful-paint}
         1. <a>Potentially add a LargestContentfulPaint entry</a> with |candidate|, |intersectionRect|, |now|, |record|'s [=pending image record/loadTime=] and |document|.
     1. [=list/For each=] |textNode| of |paintedTextNodes|,
         1. If |textNode| is not [=exposed for paint timing=], given |document|, continue.
+        1. If |textNode| is transparent or otherwise invisible, continue.
         1. Let |candidate| be (|textNode|, null)
         1. Let |intersectionRect| be an empty rectangle.
         1. [=set/For each=] {{Text}} <a>node</a> |text| of |textNode|'s <a>set of owned text nodes</a>:


### PR DESCRIPTION
Invisible texts, specifically, transparent texts with alpha channel <=0 or opacity>=0 and no text shadow and no text stroke decorations, should not be eligible for being LCP candidates.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/haoliuk/largest-contentful-paint/pull/124.html" title="Last updated on Oct 22, 2024, 7:30 PM UTC (1e9a042)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/124/06358fd...haoliuk:1e9a042.html" title="Last updated on Oct 22, 2024, 7:30 PM UTC (1e9a042)">Diff</a>