### PR TITLE
Fix renderTime reference

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -150,6 +150,7 @@ Largest Contentful Paint involves the following new interface:
 [Exposed=Window]
 interface LargestContentfulPaint : PerformanceEntry {
     readonly attribute DOMHighResTimeStamp loadTime;
+    readonly attribute DOMHighResTimeStamp renderTime;
     readonly attribute unsigned long size;
     readonly attribute DOMString id;
     readonly attribute DOMString url;

--- a/index.bs
+++ b/index.bs
@@ -171,10 +171,11 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the empty string.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return the [=default paint timestamp=] given [=this=]'s [=PaintTimingMixin/paint timing info=] if it is not 0,
-    and the value of [=this=]'s [=LargestContentfulPaint/loadTime=] otherwise.
+The {{PerformanceEntry/startTime}} attribute's getter must return the value of [=this=]'s {{LargestContentfulPaint/renderTime}} if it is not 0, and the value of [=this=]'s [=LargestContentfulPaint/loadTime=] otherwise.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
+
+The {{LargestContentfulPaint/renderTime}} attribute must return the [=default paint timestamp=] given [=this=]'s [=PaintTimingMixin/paint timing info=].
 
 The {{LargestContentfulPaint/loadTime}} attribute must return the value of [=this=]'s [=LargestContentfulPaint/loadTime=].
 

--- a/index.bs
+++ b/index.bs
@@ -171,11 +171,10 @@ The {{PerformanceEntry/entryType}} attribute's getter must return the {{DOMStrin
 
 The {{PerformanceEntry/name}} attribute's getter must return the empty string.
 
-The {{PerformanceEntry/startTime}} attribute's getter must return the value of [=this=]'s {{LargestContentfulPaint/renderTime}} if it is not 0, and the value of [=this=]'s [=LargestContentfulPaint/loadTime=] otherwise.
+The {{PerformanceEntry/startTime}} attribute's getter must return the [=default paint timestamp=] given [=this=]'s [=PaintTimingMixin/paint timing info=] if it is not 0,
+    and the value of [=this=]'s [=LargestContentfulPaint/loadTime=] otherwise.
 
 The {{PerformanceEntry/duration}} attribute's getter must return 0.
-
-The {{LargestContentfulPaint/renderTime}} attribute must return the [=default paint timestamp=] given [=this=]'s [=PaintTimingMixin/paint timing info=].
 
 The {{LargestContentfulPaint/loadTime}} attribute must return the value of [=this=]'s [=LargestContentfulPaint/loadTime=].
 


### PR DESCRIPTION
Instead of pointing to "renderTime", point to the same thing that ElementTiming's renderTime points to (the default paint timestamp).

See #133


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/pull/136.html" title="Last updated on Aug 11, 2025, 12:51 PM UTC (6af71ad)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/largest-contentful-paint/136/caa40a6...6af71ad.html" title="Last updated on Aug 11, 2025, 12:51 PM UTC (6af71ad)">Diff</a>